### PR TITLE
Updating local data config default to have 32 mnist entries

### DIFF
--- a/bin/federations/local_data_config.yaml
+++ b/bin/federations/local_data_config.yaml
@@ -62,45 +62,67 @@ collaborators:
     cifar10_shard: 9
   col_10:
     brats: '<symlink_dir>/0'
+    mnist_shard: 10
   col_11:
     brats: '<symlink_dir>/1'
+    mnist_shard: 11
   col_12:
     brats: '<symlink_dir>/2'
+    mnist_shard: 12
   col_13:
     brats: '<symlink_dir>/3'
+    mnist_shard: 13
   col_14:
     brats: '<symlink_dir>/4'
+    mnist_shard: 14
   col_15:
     brats: '<symlink_dir>/5'
+    mnist_shard: 15
   col_16:
     brats: '<symlink_dir>/6'
+    mnist_shard: 16
   col_17:
     brats: '<symlink_dir>/7'
+    mnist_shard: 17
   col_18:
     brats: '<symlink_dir>/8'
+    mnist_shard: 18
   col_19:
     brats: '<symlink_dir>/9'
+    mnist_shard: 19
   col_20:
     brats: '<symlink_dir>/0'
+    mnist_shard: 20
   col_21:
     brats: '<symlink_dir>/1'
+    mnist_shard: 21
   col_22:
     brats: '<symlink_dir>/2'
+    mnist_shard: 22
   col_23:
     brats: '<symlink_dir>/3'
+    mnist_shard: 23
   col_24:
     brats: '<symlink_dir>/4'
+    mnist_shard: 24
   col_25:
     brats: '<symlink_dir>/5'
+    mnist_shard: 25
   col_26:
     brats: '<symlink_dir>/6'
+    mnist_shard: 26
   col_27:
     brats: '<symlink_dir>/7'
+    mnist_shard: 27
   col_28:
     brats: '<symlink_dir>/8'
+    mnist_shard: 28
   col_29:
     brats: '<symlink_dir>/9'
+    mnist_shard: 29
   col_30:
     brats: '<symlink_dir>/0'
+    mnist_shard: 30
   col_31:
     brats: '<symlink_dir>/1'
+    mnist_shard: 31

--- a/bin/federations/plans/keras_cnn_mnist_32.yaml
+++ b/bin/federations/plans/keras_cnn_mnist_32.yaml
@@ -1,0 +1,44 @@
+# Copyright (C) 2020 Intel Corporation
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Compose an FL plan in YAML
+# The plan is consumed by bin/run_simulation_from_flplan.py,
+# bin/run_aggregator_from_flplan, bin/run_collaborator_from_flplan, and
+# bin/create_initial_weights_file_from_plan.py
+
+aggregator_object_init:
+  init_kwargs:
+    best_model_fname: keras_cnn_mnist_best.pbuf
+    init_model_fname: keras_cnn_mnist_init.pbuf
+    latest_model_fname: keras_cnn_mnist_latest.pbuf
+    rounds_to_train: 6
+
+collaborator_object_init:
+  init_kwargs:
+    epochs_per_round: 1.0
+    opt_treatment: RESET
+    polling_interval: 4
+    send_model_deltas: false
+
+data_object_init:
+  class_to_init: openfl.data.tensorflow.tfmnist_inmemory.TensorFlowMNISTInMemory
+  data_name_in_local_config: mnist_shard
+  init_kwargs:
+    batch_size: 256
+    nb_collaborators: 32
+
+model_object_init:
+  class_to_init: openfl.models.tensorflow.keras_cnn.keras_cnn.KerasCNN
+
+network_object_init:
+  defaults_file: defaults/network.yaml

--- a/docs/running_federation_simulation.tutorial_mnist.rst
+++ b/docs/running_federation_simulation.tutorial_mnist.rst
@@ -77,5 +77,5 @@ Note that aggregator.log is always appended to, so will include results from pre
 Explore Modifications
 ----------------------
 
-7. Edit the plan and related files to train for more rounds, more collaborators etc.
+7. Perform a new simulation using 32 collaborators instead of 10 (using the plan, 'keras_cnn_mnist_32.yaml') to see how this effects the learning curve. Explore further modifications by copying and editing existing plans.
 


### PR DESCRIPTION
Allows running of dummy_32.yaml plan. I also add an mnist 32 collaborator plan and include a suggestion to run this after running the 10 collaborator example for simulation.